### PR TITLE
Default project dir value

### DIFF
--- a/project.go
+++ b/project.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io"
+	"os"
 	"os/exec"
 
 	"fyne.io/fyne/v2"
@@ -37,6 +38,19 @@ func (d *defyne) showNewProjectDialog(w fyne.Window) {
 	}, func(ok bool) {
 		if !ok {
 			return
+		} else if dir == nil {
+			homeDir, homeDirErr := os.UserHomeDir()
+			if homeDirErr != nil {
+				dialog.ShowError(homeDirErr, w)
+				return
+			}
+			defaultDir := storage.NewFileURI(homeDir)
+			newDir, newDirErr := storage.ListerForURI(defaultDir)
+			if newDirErr != nil {
+				dialog.ShowError(newDirErr, w)
+				return
+			}
+			dir = newDir
 		}
 
 		dir, err := createProject(dir, name.Text)


### PR DESCRIPTION
Currently, if you start defyne without specifying a directory, you get prompted to select a project to open or create a new project. Creating a new project causes a nil reference as the value of `dir` in `createProject()` is still undefined.
This patch uses the home directory (via `os.UserHomeDir`) as a suitable default path value to avoid a crash when the user enters a project name without specifying a directory to place the new project in.
Andy mentioned that there are bonus points for extending this patch by storing the last-opened project in persistent storage via App.Preferences.