### PR TITLE
Improvements to which menus we show

### DIFF
--- a/menus.go
+++ b/menus.go
@@ -85,6 +85,28 @@ func (d *defyne) menuActionFullScreenToggle() {
 	d.win.SetFullScreen(!d.win.FullScreen())
 }
 
+func (d *defyne) makeHelpMenu() *fyne.Menu {
+	return fyne.NewMenu("Help",
+		fyne.NewMenuItem("Documentation", func() {
+			u, _ := url.Parse("https://fyne.io/defyne")
+			_ = fyne.CurrentApp().OpenURL(u)
+		}),
+		fyne.NewMenuItem("Support", func() {
+			u, _ := url.Parse("https://fyne.io/support")
+			_ = fyne.CurrentApp().OpenURL(u)
+		}),
+		fyne.NewMenuItemSeparator(),
+		fyne.NewMenuItem("Check Environment...", func() {
+			envcheck.ShowEnvCheckDialog(d.win)
+		}),
+		fyne.NewMenuItemSeparator(),
+		fyne.NewMenuItem("Sponsor", func() {
+			u, _ := url.Parse("https://fyne.io/sponsor")
+			_ = fyne.CurrentApp().OpenURL(u)
+		}),
+	)
+}
+
 func (d *defyne) makeMenu() *fyne.MainMenu {
 	return fyne.NewMainMenu(
 		fyne.NewMenu("File",
@@ -100,25 +122,7 @@ func (d *defyne) makeMenu() *fyne.MainMenu {
 		fyne.NewMenu("Window",
 			fyne.NewMenuItem("Full Screen", d.menuActionFullScreenToggle),
 		),
-		fyne.NewMenu("Help",
-			fyne.NewMenuItem("Documentation", func() {
-				u, _ := url.Parse("https://fyne.io/defyne")
-				_ = fyne.CurrentApp().OpenURL(u)
-			}),
-			fyne.NewMenuItem("Support", func() {
-				u, _ := url.Parse("https://fyne.io/support")
-				_ = fyne.CurrentApp().OpenURL(u)
-			}),
-			fyne.NewMenuItemSeparator(),
-			fyne.NewMenuItem("Check Environment...", func() {
-				envcheck.ShowEnvCheckDialog(d.win)
-			}),
-			fyne.NewMenuItemSeparator(),
-			fyne.NewMenuItem("Sponsor", func() {
-				u, _ := url.Parse("https://fyne.io/sponsor")
-				_ = fyne.CurrentApp().OpenURL(u)
-			}),
-		),
+		d.makeHelpMenu(),
 	)
 }
 

--- a/menus.go
+++ b/menus.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/fyne-io/defyne/internal/envcheck"
@@ -108,7 +109,7 @@ func (d *defyne) makeHelpMenu() *fyne.Menu {
 }
 
 func (d *defyne) makeMenu() *fyne.MainMenu {
-	return fyne.NewMainMenu(
+	menu := fyne.NewMainMenu(
 		fyne.NewMenu("File",
 			fyne.NewMenuItem("Open Project...", d.showProjectSelect),
 			fyne.NewMenuItemSeparator(),
@@ -118,12 +119,17 @@ func (d *defyne) makeMenu() *fyne.MainMenu {
 			fyne.NewMenuItemSeparator(),
 			fyne.NewMenuItem("Run", d.menuActionRun),
 			fyne.NewMenuItem("Run Project", d.menuActionRunProject),
-		),
-		fyne.NewMenu("Window",
-			fyne.NewMenuItem("Full Screen", d.menuActionFullScreenToggle),
-		),
+		))
+	if runtime.GOOS != "darwin" {
+		menu.Items = append(menu.Items,
+			fyne.NewMenu("Window",
+				fyne.NewMenuItem("Full Screen", d.menuActionFullScreenToggle),
+			))
+	}
+	menu.Items = append(menu.Items,
 		d.makeHelpMenu(),
 	)
+	return menu
 }
 
 func (d *defyne) makeToolbar() *widget.Toolbar {

--- a/project.go
+++ b/project.go
@@ -77,12 +77,14 @@ func (d *defyne) showOpenProjectDialog(w fyne.Window) {
 func (d *defyne) showProjectSelect() {
 	a := fyne.CurrentApp()
 	w := a.NewWindow("Defyne : Open Project")
-	w.SetMainMenu(fyne.NewMainMenu(
-		fyne.NewMenu("File",
-			fyne.NewMenuItem("Open Project...", w.Show),
-		),
-		d.makeHelpMenu(),
-	))
+	if d.projectRoot == nil { // this is our welcome screen
+		w.SetMainMenu(fyne.NewMainMenu(
+			fyne.NewMenu("File",
+				fyne.NewMenuItem("Open Project...", w.Show),
+			),
+			d.makeHelpMenu(),
+		))
+	}
 
 	img := canvas.NewImageFromResource(resourceIconPng)
 	img.FillMode = canvas.ImageFillContain

--- a/project.go
+++ b/project.go
@@ -77,6 +77,12 @@ func (d *defyne) showOpenProjectDialog(w fyne.Window) {
 func (d *defyne) showProjectSelect() {
 	a := fyne.CurrentApp()
 	w := a.NewWindow("Defyne : Open Project")
+	w.SetMainMenu(fyne.NewMainMenu(
+		fyne.NewMenu("File",
+			fyne.NewMenuItem("Open Project...", w.Show),
+		),
+		d.makeHelpMenu(),
+	))
 
 	img := canvas.NewImageFromResource(resourceIconPng)
 	img.FillMode = canvas.ImageFillContain


### PR DESCRIPTION
Show a basic menu when the welcome project selection screen is visible.
Don't duplicate the Window menu that macOS provides.
