### PR TITLE
Use VBox instead of Stack layout for new containers

### DIFF
--- a/internal/guidefs/containers.go
+++ b/internal/guidefs/containers.go
@@ -17,7 +17,7 @@ func initContainers() {
 		"*fyne.Container": {
 			Name: "Container",
 			Create: func() fyne.CanvasObject {
-				return container.NewStack()
+				return container.NewVBox()
 			},
 			Edit: func(obj fyne.CanvasObject, props map[string]string, refresh func([]*widget.FormItem)) []*widget.FormItem {
 				c := obj.(*fyne.Container)
@@ -45,7 +45,7 @@ func initContainers() {
 				c := obj.(*fyne.Container)
 				l := props[c]["layout"]
 				if l == "" {
-					l = "Stack"
+					l = "VBox"
 				}
 				lay := Layouts[l]
 				if lay.goText != nil {


### PR DESCRIPTION
Currently new containers get the `Stack` layout, but from a visual perspective `VBox` seems to be a better starting point and easier to understand.